### PR TITLE
Stop the processing if the inspector.selection is not connected

### DIFF
--- a/extension/experiments/inspectedNode/api.js
+++ b/extension/experiments/inspectedNode/api.js
@@ -44,6 +44,9 @@ this.inspectedNode = class extends ExtensionAPI {
       await _setupClientIfNeeded(clientId);
 
       const { inspector } = _clients.get(clientId);
+      if (!inspector.selection.isConnected()) {
+        return [];
+      }
 
       const node = inspector.selection.nodeFront;
       const styles =


### PR DESCRIPTION
The nodeFront will be null in case the inspector.selection is not connected.
And passing the null to inspector.pageStyle.getApplied() causes an error at the actor.