### PR TITLE
Correspnd to backward compatibility (target to currentTarget)

### DIFF
--- a/extension/experiments/inspectedNode/api.js
+++ b/extension/experiments/inspectedNode/api.js
@@ -18,7 +18,8 @@ this.inspectedNode = class extends ExtensionAPI {
       client.onNodeChange = onNodeChange;
 
       const { inspector } = client;
-      const changesFront = await inspector.currentTarget.getFront("changes");
+      const target = inspector.currentTarget || inspector.target;
+      const changesFront = await target.getFront("changes");
       // We call `allChanges()` to activate emiting all events from the actor now.
       // When the Bug 1563757 fixes, we can remove.
       // https://bugzilla.mozilla.org/show_bug.cgi?id=1563757
@@ -35,7 +36,8 @@ this.inspectedNode = class extends ExtensionAPI {
       // invalidated before dependencies have a chance to unregister. This guard is here
       // to prevent throwing errors as a result of trying to work on an unavailable front.
       try {
-        const changesFront = await inspector.currentTarget.getFront("changes");
+        const target = inspector.currentTarget || inspector.target;
+        const changesFront = await target.getFront("changes");
         changesFront.off("clear-changes", onNodeChange);
         changesFront.off("remove-change", onNodeChange);
         changesFront.off("add-change", onNodeChange);


### PR DESCRIPTION
Sorry, I used `currentTarget` instead of `target` in the last PR though, I want to keep `target` for the developer edition.